### PR TITLE
feature/SAL3.10 - salobj 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,4 @@
-FROM lsstts/develop-env:develop
-WORKDIR /home/saluser/repos/ts_sal
-RUN source /opt/lsst/software/stack/loadLSST.bash && setup lsst_distrib && \
-    source /home/saluser/repos/ts_sal/setup.env && \
-    eups declare -r . ts_sal -t current && \
-    setup ts_sal -t current && \
-    scons && \
-    make_salpy_libs.py ATDome ATMCS
+FROM lsstts/develop-env:20190610_sal3.10.0_salobj3.12.0
 
 WORKDIR /usr/src/love
 COPY producer/requirements.txt .

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,11 +1,5 @@
 FROM lsstts/develop-env:20190610_sal3.10.0_salobj3.12.0
-WORKDIR /home/saluser/repos/ts_sal
-RUN source /opt/lsst/software/stack/loadLSST.bash && setup lsst_distrib && \
-    source /home/saluser/repos/ts_sal/setup.env && \
-    eups declare -r . ts_sal -t current && \
-    setup ts_sal -t current && \
-    scons && \
-    make_salpy_libs.py ATDome ATMCS
+
 
 
 WORKDIR /usr/src/love


### PR DESCRIPTION
Update Dockerfiles to use SAL 3.10 and salobj 3.12 develop environment which already includes the ATDome, ATMCS SALPY libraries.