### PR TITLE
WIP: Add optional heartbeat param to be read from config

### DIFF
--- a/producer/base_ws_client.py
+++ b/producer/base_ws_client.py
@@ -109,14 +109,20 @@ class BaseWSClient():
         if key:
             for csc_instance in data[key]:
                 index = 0
+                heartbeat = True
                 if 'index' in csc_instance:
                     index = csc_instance['index']
-                csc_list.append((key, index))
+                if 'heartbeat' in csc_instance:
+                    heartbeat = csc_instance['heartbeat']
+                csc_list.append((key, index, heartbeat))
         else:
             for csc_key, csc_value in data.items():
                 for csc_instance in csc_value:
                     index = 0
+                    heartbeat = True
                     if 'index' in csc_instance:
                         index = csc_instance['index']
-                    csc_list.append((csc_key, index))
+                    if 'heartbeat' in csc_instance:
+                        heartbeat = csc_instance['heartbeat']
+                    csc_list.append((csc_key, index, heartbeat))
         return csc_list

--- a/producer/command_receiver/receiver.py
+++ b/producer/command_receiver/receiver.py
@@ -11,7 +11,7 @@ class Receiver:
 
     def __init__(self, domain, csc_list):
         self.remote_dict = {}
-        for name, salindex in csc_list:
+        for name, salindex, heartbeat in csc_list:
             print('- Listening to commands for CSC: ', (name, salindex))
             try:
                 remote = salobj.Remote(domain=domain, name=name, index=salindex)

--- a/producer/events/producer.py
+++ b/producer/events/producer.py
@@ -13,7 +13,7 @@ class EventsProducer:
         self.events_callback = events_callback
         self.remote_dict = {}
         self.initial_state_remote_dict = {}
-        for name, salindex in csc_list:
+        for name, salindex, heartbeat in csc_list:
             try:
                 print('- Listening to events from CSC: ', (name, salindex))
                 remote = salobj.Remote(domain=domain, name=name, index=salindex)

--- a/producer/heartbeats/producer.py
+++ b/producer/heartbeats/producer.py
@@ -42,9 +42,9 @@ class HeartbeatProducer:
             sal_lib_params = self.csc_list[i]
             sal_lib_name = sal_lib_params[0]
             print('- Listening to heartbeats from CSC: ', sal_lib_params)
-            [sal_lib_name, index] = sal_lib_params
-
-            asyncio.get_event_loop().create_task(self.monitor_remote_heartbeat(sal_lib_name, index))
+            [sal_lib_name, index, heartbeat] = sal_lib_params
+            if heartbeat:
+                asyncio.get_event_loop().create_task(self.monitor_remote_heartbeat(sal_lib_name, index))
 
     def get_heartbeat_message(self, remote_name, salindex, nlost_subsequent, timestamp):
         """Generates a message with the heartbeat info of a CSC in dictionary format.

--- a/producer/scriptqueue/client.py
+++ b/producer/scriptqueue/client.py
@@ -49,7 +49,7 @@ async def init_client(salindex):
 async def main():
     sq_list = BaseWSClient.read_config(BaseWSClient.path, 'ScriptQueue')
     print('List of Script Queues to listen:', sq_list)
-    for name, salindex in sq_list:
+    for name, salindex, heartbeat in sq_list:
         asyncio.create_task(init_client(salindex))
 
 

--- a/producer/telemetries/producer.py
+++ b/producer/telemetries/producer.py
@@ -11,7 +11,7 @@ class TelemetriesProducer:
 
     def __init__(self, domain, csc_list):
         self.remote_list = []
-        for name, salindex in csc_list:
+        for name, salindex, heartbeat in csc_list:
             try:
                 remote = salobj.Remote(domain=domain, name=name, index=salindex)
                 self.remote_list.append(remote)


### PR DESCRIPTION
Adds optional heartbeat param for the config file, to avoid sending missing heartbeats messages from CSCs which don't have them implemented. A sample config.json would look like:

```json
{
  "ATMCS": [{ "source": "command_sim" }],
  "ATDome": [{ "source": "command_sim" }],
  "Watcher": [{ "index": 0, "source": "command_sim" }],
  "GenericCamera": [{ "index": 1, "source": "command_sim", "heartbeat": false}],
  "ScriptQueue": [{ "index": 1, "source": "command_sim" }],
  "LOVE": [{ "index": 0, "source": "" }]
}
```