### PR TITLE
Load new remotes on initial_state requests

### DIFF
--- a/producer/events/test_client.py
+++ b/producer/events/test_client.py
@@ -1,0 +1,93 @@
+import asynctest
+import asyncio
+import json
+from lsst.ts import salobj
+import test_utils
+import utils
+
+STD_TIMEOUT = 15  # timeout for command ack
+SHOW_LOG_MESSAGES = False
+
+index_gen = salobj.index_generator()
+
+class TestEventsClient(test_utils.WSClientTestCase):
+    async def test_valid_remote_not_in_config(self):
+        async def arrange():
+            from events.client import EventsWSClient
+            salobj.set_random_lsst_dds_domain()
+            self.index = next(index_gen)
+            self.csc = salobj.TestCsc(index=self.index, config_dir=None, initial_state=salobj.State.ENABLED)
+            self.remote = salobj.Remote(domain=self.csc.domain, name="Test", index=self.index)
+
+            self.client = EventsWSClient()
+            self.client_task = asyncio.create_task(self.client.start_ws_client())
+        
+        async def act_assert(websocket, path):
+            # ARRANGE wait for the client to connect to initial_state group
+            # this ensures the harness will run the arrange() first
+            initial_subscription = await websocket.recv()
+            self.assertEqual(json.loads(initial_subscription), {
+                'option': 'subscribe',
+                'category': 'initial_state',
+                'csc': 'all',
+                'salindex': 'all',
+                'stream': 'all'})
+
+            # ASSERT remote does not exist in current instance
+            self.assertNotIn(('Test', 1), self.client.producer.initial_state_remote_dict)
+            self.assertNotIn(('Test', 1), self.client.producer.remote_dict)
+
+            # ARRANGE: fill in some data            
+            cmd_data_sent = self.csc.make_random_cmd_scalars()
+            await self.remote.cmd_setScalars.start(cmd_data_sent, timeout=STD_TIMEOUT)
+            evt_scalars = await self.remote.evt_scalars.next(flush=False)
+            
+            # ACT: request initial data of a new csc
+            message = utils.make_stream_message('initial_state', 'Test', 1, 'event_name', 'scalars')
+            await websocket.send(json.dumps(message))
+
+            # heartbeat events will come too, so just wait for this event
+            while True:
+                response = await websocket.recv()
+                message = json.loads(response)
+                stream_exists = utils.check_event_stream(message, 'event', 'Test', 1, 'scalars')
+                print('stream_exists', stream_exists, flush=True)
+                if stream_exists:
+                    stream = utils.get_event_stream(message, 'event', 'Test', 1, 'scalars')[0]
+                    break
+                
+
+            # ASSERT
+            # the remote exists in both dicts
+            self.assertIn(('Test', 1), self.client.producer.initial_state_remote_dict)
+            self.assertIn(('Test', 1), self.client.producer.remote_dict)
+
+            # ASSERT: message has the same data
+            evt_parameters = evt_scalars._member_attributes
+            expected_stream = {
+                p: {
+                    'value': getattr(evt_scalars, p),
+                    'dataType': utils.getDataType(getattr(evt_scalars, p))
+                }
+                for p in evt_parameters if p != "private_rcvStamp"
+            }
+            self.maxDiff = None
+            del stream['private_rcvStamp']
+            self.assertEqual(stream, expected_stream)
+
+        async def cleanup():
+            # cleanup
+            self.client.retry = False
+            self.client_task.cancel()
+            await self.client_task
+
+            await self.csc.close()
+            await self.remote.close()
+            for (remote, index) in self.client.producer.initial_state_remote_dict:
+                await self.client.producer.initial_state_remote_dict[(remote,index)].close()
+            
+            for (remote, index) in self.client.producer.initial_state_remote_dict:
+                await self.client.producer.initial_state_remote_dict[(remote,index)].close()
+
+            
+        await self.harness(act_assert, arrange, cleanup)

--- a/producer/love_csc/test.py
+++ b/producer/love_csc/test.py
@@ -1,12 +1,10 @@
 import asynctest
-from asynctest import mock
-import os
 import asyncio
 from lsst.ts import salobj
-import websockets
 from love_csc.csc import LOVECsc
 import utils
 import json
+from test_utils import WSClientTestCase
 
 STD_TIMEOUT = 15  # timeout for command ack
 SHOW_LOG_MESSAGES = False
@@ -36,36 +34,6 @@ class TestLOVECsc(asynctest.TestCase):
         # clean up
         await self.csc.close()
         await self.remote.close()
-
-
-class WSClientTestCase(asynctest.TestCase):
-    """ Class to run tests with a mock-up ws server"""
-    @mock.patch.dict(os.environ, {'WEBSOCKET_HOST': '0.0.0.0:9999', 'PROCESS_CONNECTION_PASS': ''})
-    async def harness(self, act_assert=None, arrange=None, cleanup=None):
-        """ Runs the `act_assert` coroutine callback after starting a websockets server.
-        Asynchronously it first runs the arrange and cleanup coroutines before
-        and after the act_assert finishes.
-
-        act_assert will receive (websocket, path) from the websockets.serve function.
-        """
-        if act_assert is None:
-            act_assert = asyncio.sleep(0)
-        if arrange is None:
-            arrange = asyncio.sleep(0)
-        if cleanup is None:
-            cleanup = asyncio.sleep(0)
-
-        test_finished = asyncio.Future()
-
-        async def act_assert_wrapper(*args, **kwargs):
-            await act_assert(*args, **kwargs)
-            test_finished.set_result(True)
-
-        async with websockets.serve(act_assert_wrapper, '0.0.0.0', 9999):
-            await arrange()
-            await asyncio.wait_for(test_finished, timeout=STD_TIMEOUT*2)
-            await cleanup()
-
 
 class TestWebsocketsClient(WSClientTestCase):
     async def test_csc_client(self):

--- a/producer/love_csc/test.py
+++ b/producer/love_csc/test.py
@@ -38,10 +38,25 @@ class TestLOVECsc(asynctest.TestCase):
         await self.remote.close()
 
 
-class TestWebsocketsClient(asynctest.TestCase):
+class WSClientTestCase(asynctest.TestCase):
+    """ Class to run tests with a mock-up ws server"""
     @mock.patch.dict(os.environ, {'WEBSOCKET_HOST': '0.0.0.0:9999', 'PROCESS_CONNECTION_PASS': ''})
-    async def harness(self, act_assert, arrange, cleanup):
+    async def harness(self, act_assert=None, arrange=None, cleanup=None):
+        """ Runs the `act_assert` coroutine callback after starting a websockets server.
+        Asynchronously it first runs the arrange and cleanup coroutines before
+        and after the act_assert finishes.
+
+        act_assert will receive (websocket, path) from the websockets.serve function.
+        """
+        if act_assert is None:
+            act_assert = asyncio.sleep(0)
+        if arrange is None:
+            arrange = asyncio.sleep(0)
+        if cleanup is None:
+            cleanup = asyncio.sleep(0)
+
         test_finished = asyncio.Future()
+
         async def act_assert_wrapper(*args, **kwargs):
             await act_assert(*args, **kwargs)
             test_finished.set_result(True)
@@ -51,6 +66,8 @@ class TestWebsocketsClient(asynctest.TestCase):
             await asyncio.wait_for(test_finished, timeout=STD_TIMEOUT*2)
             await cleanup()
 
+
+class TestWebsocketsClient(WSClientTestCase):
     async def test_csc_client(self):
         async def arrange():
             from love_csc.client import LOVEWSClient

--- a/producer/test_utils.py
+++ b/producer/test_utils.py
@@ -1,0 +1,37 @@
+import asynctest
+from asynctest import mock
+import asyncio
+import websockets
+import os
+
+STD_TIMEOUT = 15  # timeout for command ack
+
+
+class WSClientTestCase(asynctest.TestCase):
+    """ Class to run tests with a mock-up ws server"""
+
+    @mock.patch.dict(os.environ, {'WEBSOCKET_HOST': '0.0.0.0:9999', 'PROCESS_CONNECTION_PASS': ''})
+    async def harness(self, act_assert=None, arrange=None, cleanup=None):
+        """ Runs the `act_assert` coroutine callback after starting a websockets server.
+        Asynchronously it first runs the arrange and cleanup coroutines before
+        and after the act_assert finishes.
+
+        act_assert will receive (websocket, path) from the websockets.serve function.
+        """
+        if act_assert is None:
+            act_assert = asyncio.sleep(0)
+        if arrange is None:
+            arrange = asyncio.sleep(0)
+        if cleanup is None:
+            cleanup = asyncio.sleep(0)
+
+        test_finished = asyncio.Future()
+
+        async def act_assert_wrapper(*args, **kwargs):
+            await act_assert(*args, **kwargs)
+            test_finished.set_result(True)
+
+        async with websockets.serve(act_assert_wrapper, '0.0.0.0', 9999):
+            await arrange()
+            await asyncio.wait_for(test_finished, timeout=STD_TIMEOUT*2)
+            await cleanup()


### PR DESCRIPTION
Now new remotes are added whenever an initial_state is requested with valid parameters if it did not exist before (for example, in config.json)

