### PR TITLE
Remotes refactor

### DIFF
--- a/producer/events/client.py
+++ b/producer/events/client.py
@@ -26,13 +26,6 @@ class EventsWSClient(BaseWSClient):
         await asyncio.gather(
             *[remote.start_task for remote in self.producer.remote_dict.values()]
         )
-
-        await asyncio.gather(
-            *[
-                remote.start_task
-                for remote in self.producer.initial_state_remote_dict.values()
-            ]
-        )
         self.producer.setup_callbacks()
 
     def send_message_callback(self, message):

--- a/producer/events/client.py
+++ b/producer/events/client.py
@@ -10,14 +10,14 @@ from base_ws_client import BaseWSClient
 class EventsWSClient(BaseWSClient):
     """Handles the websocket client connection between the Telemetries&Events Producer and the LOVE-manager."""
 
-    def __init__(self, csc_list=None):
+    def __init__(self, csc_list=None, remote=None):
         super().__init__(name="Events")
         if csc_list != None:
             print("CSC list replaced by", csc_list)
             self.csc_list = csc_list
         self.connection_error = False
         self.producer = EventsProducer(
-            self.domain, self.csc_list, self.send_message_callback
+            self.domain, self.csc_list, self.send_message_callback, remote=remote
         )
 
     async def on_start_client(self):

--- a/producer/events/producer.py
+++ b/producer/events/producer.py
@@ -16,6 +16,7 @@ class EventsProducer:
         self.domain = domain
         self.remote_dict = {}
         self.initial_state_remote_dict = {}
+        self.initial_state_data = {}
         for name, salindex in csc_list:
             try:
                 print("- Listening to events from CSC: ", (name, salindex))
@@ -31,15 +32,17 @@ class EventsProducer:
 
     def setup_callbacks(self):
         """Configures a callback for each remote created"""
+        tasks = []
         for (name, salindex) in self.remote_dict:
             try:
                 remote = self.remote_dict[(name, salindex)]
-                self.set_remote_evt_callbacks(remote)
+                tasks.append(self.set_remote_evt_callbacks(remote))
             except Exception as e:
                 print("- Could not setup events callback for", name, salindex)
                 print(e)
+        asyncio.gather(*tasks)
 
-    def set_remote_evt_callbacks(self, remote):
+    async def set_remote_evt_callbacks(self, remote):
         """Set the callbacks for the events of a given remote
 
         Parameters
@@ -47,9 +50,19 @@ class EventsProducer:
         remote: object
             The remote to set callbacks to
         """
+        remote_name = remote.salinfo.name
+        index = remote.salinfo.index
         evt_names = remote.salinfo.event_names
+        await remote.start_task
         for evt in evt_names:
-            evt_object = getattr(remote, "evt_" + evt)
+            evt_key = f"evt_{evt}"
+            evt_object = getattr(remote, evt_key)
+            # aget before setting callback
+            try:
+                evt_data = evt_object.get()
+                self.initial_state_data[(remote_name, index, evt)] = evt_data
+            except Exception as e:
+                self.initial_state_data[(remote_name, index, evt)] = None
             evt_object.callback = self.make_callback(
                 remote.salinfo.name, remote.salinfo.index, evt
             )
@@ -77,7 +90,10 @@ class EventsProducer:
                 rcv_time = Time.now().tai.datetime.timestamp()
             evt_parameters = list(evt_data._member_attributes)
             remote = self.remote_dict[(csc, salindex)]
+            remote_name = remote.salinfo.name
+            index = remote.salinfo.index
             evt_object = getattr(remote, f"evt_{evt_name}")
+            self.initial_state_data[(remote_name, index, evt_name)] = evt_object.get()
             evt_result = {
                 p: {
                     "value": getattr(evt_data, p),
@@ -155,13 +171,18 @@ class EventsProducer:
                 return
 
         remote = self.initial_state_remote_dict[(csc, salindex)]
+        remote_name = remote.salinfo.name
+        index = remote.salinfo.index
 
         # safely request event data
-        await remote.start_task
-        evt_object = getattr(remote, "evt_{}".format(event_name))
+        # await remote.start_task
+        evt_object = getattr(remote, f"evt_{event_name}")
         try:
             # get most recent data or wait TIMEOUT seconds for the first one
-            evt_data = await evt_object.aget(timeout=TIMEOUT)
+            key = (remote_name, index, event_name)
+            evt_data = None
+            if key in self.initial_state_data:
+                evt_data = self.initial_state_data[(remote_name, index, event_name)]
             if evt_data is None:
                 return
         except Exception as e:

--- a/producer/events/producer.py
+++ b/producer/events/producer.py
@@ -15,16 +15,12 @@ class EventsProducer:
         self.events_callback = events_callback
         self.domain = domain
         self.remote_dict = {}
-        self.initial_state_remote_dict = {}
         self.initial_state_data = {}
         for name, salindex in csc_list:
             try:
                 print("- Listening to events from CSC: ", (name, salindex))
                 remote = salobj.Remote(domain=domain, name=name, index=salindex)
                 self.remote_dict[(name, salindex)] = remote
-                self.initial_state_remote_dict[(name, salindex)] = salobj.Remote(
-                    domain=domain, name=name, index=salindex
-                )
 
             except Exception as e:
                 print("- Could not load events remote for", name, salindex)
@@ -163,20 +159,15 @@ class EventsProducer:
                 self.remote_dict[(csc, salindex)] = salobj.Remote(
                     self.domain, csc, salindex
                 )
-                self.initial_state_remote_dict[(csc, salindex)] = salobj.Remote(
-                    domain=self.domain, name=csc, index=salindex
-                )
-                self.set_remote_evt_callbacks(self.remote_dict[(csc, salindex)])
+                await self.set_remote_evt_callbacks(self.remote_dict[(csc, salindex)])
             except RuntimeError:
                 return
 
-        remote = self.initial_state_remote_dict[(csc, salindex)]
+        remote = self.remote_dict[(csc, salindex)]
         remote_name = remote.salinfo.name
         index = remote.salinfo.index
 
         # safely request event data
-        # await remote.start_task
-        evt_object = getattr(remote, f"evt_{event_name}")
         try:
             # get most recent data or wait TIMEOUT seconds for the first one
             key = (remote_name, index, event_name)

--- a/producer/events/producer.py
+++ b/producer/events/producer.py
@@ -11,20 +11,25 @@ TIMEOUT = 10
 class EventsProducer:
     """ Produces messages with events coming from several CSCs """
 
-    def __init__(self, domain, csc_list, events_callback):
+    def __init__(self, domain, csc_list, events_callback, remote=None):
         self.events_callback = events_callback
         self.domain = domain
         self.remote_dict = {}
         self.initial_state_data = {}
-        for name, salindex in csc_list:
-            try:
-                print("- Listening to events from CSC: ", (name, salindex))
-                remote = salobj.Remote(domain=domain, name=name, index=salindex)
-                self.remote_dict[(name, salindex)] = remote
+        if not remote:
+            for name, salindex in csc_list:
+                try:
+                    print("- Listening to events from CSC: ", (name, salindex))
+                    new_remote = salobj.Remote(domain=domain, name=name, index=salindex)
+                    self.remote_dict[(name, salindex)] = new_remote
 
-            except Exception as e:
-                print("- Could not load events remote for", name, salindex)
-                print(e)
+                except Exception as e:
+                    print("- Could not load events remote for", name, salindex)
+                    print(e)
+        else:
+            name = remote.salinfo.name
+            salindex = remote.salinfo.index
+            self.remote_dict[(name, salindex)] = remote
 
     def setup_callbacks(self):
         """Configures a callback for each remote created"""

--- a/producer/events/test_client.py
+++ b/producer/events/test_client.py
@@ -98,8 +98,5 @@ class TestEventsClient(test_utils.WSClientTestCase):
 
             for (csc, salindex) in self.client.producer.remote_dict:
                 await self.client.producer.remote_dict[(csc, salindex)].close()
-                await self.client.producer.initial_state_remote_dict[
-                    (csc, salindex)
-                ].close()
 
         await self.harness(act_assert, arrange, cleanup)

--- a/producer/events/test_producer.py
+++ b/producer/events/test_producer.py
@@ -22,7 +22,6 @@ class TestEventsMessages(asynctest.TestCase):
             index=index, config_dir=None, initial_state=salobj.State.ENABLED
         )
         self.remote = salobj.Remote(domain=self.csc.domain, name="Test", index=index)
-        await self.remote.start_task
 
         self.message_queue = asyncio.Queue()
         self.callback = lambda message: asyncio.create_task(
@@ -57,6 +56,7 @@ class TestEventsMessages(asynctest.TestCase):
         )
         self.events_producer.setup_callbacks()
         cmd_data_sent = self.csc.make_random_cmd_scalars()
+        await self.remote.start_task
         await self.remote.cmd_setScalars.start(cmd_data_sent, timeout=STD_TIMEOUT)
 
         # Act
@@ -89,6 +89,7 @@ class TestEventsMessages(asynctest.TestCase):
         self.events_producer.setup_callbacks()
         # Setup the producer and the data
         cmd_data_sent = self.csc.make_random_cmd_arrays()
+        await self.remote.start_task
         await self.remote.cmd_setArrays.start(cmd_data_sent, timeout=STD_TIMEOUT)
 
         # Act
@@ -120,6 +121,7 @@ class TestEventsMessages(asynctest.TestCase):
         )
         self.events_producer.setup_callbacks()
         cmd_data_sent = self.csc.make_random_cmd_scalars()
+        await self.remote.start_task
         await self.remote.cmd_setScalars.start(cmd_data_sent, timeout=STD_TIMEOUT)
 
         # Act

--- a/producer/events/test_producer.py
+++ b/producer/events/test_producer.py
@@ -28,13 +28,7 @@ class TestEventsMessages(asynctest.TestCase):
         self.callback = lambda message: asyncio.create_task(
             self.message_queue.put(message)
         )
-
-        self.events_producer = EventsProducer(
-            domain=self.csc.domain,
-            csc_list=[("Test", self.csc.salinfo.index)],
-            events_callback=self.callback,
-        )
-        self.events_producer.setup_callbacks()
+        self.events_producer = None
 
     async def tearDown(self):
         for remote in self.events_producer.remote_dict.values():
@@ -56,6 +50,12 @@ class TestEventsMessages(asynctest.TestCase):
 
     async def test_produced_message_with_event_scalar(self):
         # Arrange
+        self.events_producer = EventsProducer(
+            domain=self.csc.domain,
+            csc_list=[("Test", self.csc.salinfo.index)],
+            events_callback=self.callback,
+        )
+        self.events_producer.setup_callbacks()
         cmd_data_sent = self.csc.make_random_cmd_scalars()
         await self.remote.cmd_setScalars.start(cmd_data_sent, timeout=STD_TIMEOUT)
 
@@ -81,6 +81,12 @@ class TestEventsMessages(asynctest.TestCase):
 
     async def test_produced_message_with_event_arrays(self):
         # Arrange
+        self.events_producer = EventsProducer(
+            domain=self.csc.domain,
+            csc_list=[("Test", self.csc.salinfo.index)],
+            events_callback=self.callback,
+        )
+        self.events_producer.setup_callbacks()
         # Setup the producer and the data
         cmd_data_sent = self.csc.make_random_cmd_arrays()
         await self.remote.cmd_setArrays.start(cmd_data_sent, timeout=STD_TIMEOUT)
@@ -96,6 +102,39 @@ class TestEventsMessages(asynctest.TestCase):
             p: {
                 "value": getattr(evt_arrays, p),
                 "dataType": utils.getDataType(getattr(evt_arrays, p)),
+                "units": f"{self.remote.evt_scalars.metadata.field_info[p].units}",
+            }
+            for p in evt_parameters
+            if p != "private_rcvStamp"
+        }
+        self.assertEqual(stream, expected_stream)
+
+    async def test_produced_message_with_event_scalar_with_existing_remote(self):
+        # Arrange
+        remote = salobj.Remote(domain=self.csc.domain, name="Test", index=self.csc.salinfo.index)
+        self.events_producer = EventsProducer(
+            domain=self.csc.domain,
+            csc_list=[],
+            events_callback=self.callback,
+            remote=remote,
+        )
+        self.events_producer.setup_callbacks()
+        cmd_data_sent = self.csc.make_random_cmd_scalars()
+        await self.remote.cmd_setScalars.start(cmd_data_sent, timeout=STD_TIMEOUT)
+
+        # Act
+        stream = await asyncio.wait_for(self.wait_for_stream("scalars"), STD_TIMEOUT)
+        del stream["private_rcvStamp"]
+
+        # Assert
+        evt_scalars = await self.remote.evt_scalars.next(
+            flush=False, timeout=STD_TIMEOUT
+        )
+        evt_parameters = evt_scalars._member_attributes
+        expected_stream = {
+            p: {
+                "value": getattr(evt_scalars, p),
+                "dataType": utils.getDataType(getattr(evt_scalars, p)),
                 "units": f"{self.remote.evt_scalars.metadata.field_info[p].units}",
             }
             for p in evt_parameters

--- a/producer/heartbeats/client.py
+++ b/producer/heartbeats/client.py
@@ -11,12 +11,19 @@ from base_ws_client import BaseWSClient
 class CSCHeartbeatsWSClient(BaseWSClient):
     """Handles the websocket client connection between the Heartbeats Producer and the LOVE-manager."""
 
-    def __init__(self):
+    def __init__(self, remote=None):
+        """Initializes its producer
+
+        Parameters
+        ----------
+        remote: salobj.Remote
+            Optional Remote object, when the heartbeat of only one Remote is to be monitored
+        """
         super().__init__(name="CSCHeartbeats")
 
         self.connection_error = False
         self.producer = HeartbeatProducer(
-            self.domain, self.send_heartbeat, self.csc_list
+            self.domain, self.send_heartbeat, self.csc_list, remote
         )
 
     async def on_start_client(self):

--- a/producer/telemetries/client.py
+++ b/producer/telemetries/client.py
@@ -11,14 +11,14 @@ from base_ws_client import BaseWSClient
 class TelemetriesClient(BaseWSClient):
     """Handles the websocket client connection between the Telemetries&Events Producer and the LOVE-manager."""
 
-    def __init__(self, sleepDuration=2, csc_list=None):
+    def __init__(self, sleepDuration=2, csc_list=None, remote=None):
         super().__init__(name="Telemetries")
 
         if csc_list != None:
             self.csc_list = csc_list
             print("CSCs to listen replaced by", csc_list)
 
-        self.producer = TelemetriesProducer(self.domain, self.csc_list)
+        self.producer = TelemetriesProducer(self.domain, self.csc_list, remote)
 
         self.sleepDuration = sleepDuration
 

--- a/producer/telemetries/producer.py
+++ b/producer/telemetries/producer.py
@@ -9,16 +9,19 @@ from lsst.ts import salobj
 class TelemetriesProducer:
     """  Produces messages with telemetries coming from several CSCs """
 
-    def __init__(self, domain, csc_list):
+    def __init__(self, domain, csc_list, remote=None):
         self.remote_list = []
-        for name, salindex in csc_list:
-            try:
-                remote = salobj.Remote(domain=domain, name=name, index=salindex)
-                self.remote_list.append(remote)
+        if not remote:
+            for name, salindex in csc_list:
+                try:
+                    new_remote = salobj.Remote(domain=domain, name=name, index=salindex)
+                    self.remote_list.append(new_remote)
 
-            except Exception as e:
-                print("- Could not load telemetries remote for", name, salindex)
-                print(e)
+                except Exception as e:
+                    print("- Could not load telemetries remote for", name, salindex)
+                    print(e)
+        else:
+            self.remote_list.append(remote)
 
     def get_remote_tel_values(self, remote):
         """Get telemetries from the Remote

--- a/producer/telemetries/test_client.py
+++ b/producer/telemetries/test_client.py
@@ -96,3 +96,86 @@ class TestTelemetriesClient(test_utils.WSClientTestCase):
                 await remote.close()
 
         await self.harness(act_assert, arrange, cleanup)
+
+    async def test_produced_message_with_telemetry_scalar_with_existing_remote(self):
+        async def arrange():
+            from telemetries.client import TelemetriesClient
+
+            salobj.set_random_lsst_dds_domain()
+            self.index = next(index_gen)
+            self.csc = salobj.TestCsc(
+                index=self.index, config_dir=None, initial_state=salobj.State.ENABLED
+            )
+            await self.csc.start_task
+            self.remote = salobj.Remote(
+                domain=self.csc.domain, name="Test", index=self.index
+            )
+            await self.remote.start_task
+
+            csc_list = [("Test", self.index)]
+
+            # with patch("builtins.open", mock_open(read_data=json.dumps(config))) :
+            remote = salobj.Remote(domain=salobj.Domain(), name="Test", index=self.index)
+            self.client = TelemetriesClient(csc_list=csc_list, sleepDuration=0.5, remote=remote)
+            self.client_task = asyncio.create_task(self.client.start_ws_client())
+
+        async def act_assert(websocket, path):
+            # ARRANGE wait for the client to connect to initial_state group
+            # this ensures the harness will run the arrange() first
+            initial_subscription = await websocket.recv()
+            self.assertEqual(
+                json.loads(initial_subscription),
+                {
+                    "option": "subscribe",
+                    "category": "initial_state",
+                    "csc": "all",
+                    "salindex": "all",
+                    "stream": "all",
+                },
+            )
+
+            # ARRANGE: fill in some data
+            cmd_data_sent = self.csc.make_random_cmd_scalars()
+            await self.remote.cmd_setScalars.start(cmd_data_sent, timeout=STD_TIMEOUT)
+            tel_scalars = await self.remote.tel_scalars.next(
+                flush=False, timeout=STD_TIMEOUT
+            )
+            tel_parameters = tel_scalars._member_attributes
+            expected_stream = {
+                p: {
+                    "value": getattr(tel_scalars, p),
+                    "dataType": utils.getDataType(getattr(tel_scalars, p)),
+                    "units": f"{self.remote.tel_scalars.metadata.field_info[p].units}",
+                }
+                for p in tel_parameters
+                if p != "private_rcvStamp"
+            }
+
+            while True:
+                response = await websocket.recv()
+                message = json.loads(response)
+                stream_exists = utils.check_event_stream(
+                    message, "telemetry", "Test", self.index, "scalars"
+                )
+                if stream_exists:
+                    stream = utils.get_event_stream(
+                        message, "telemetry", "Test", self.index, "scalars"
+                    )
+                    break
+
+            del stream["private_rcvStamp"]
+
+            self.assertEqual(stream, expected_stream)
+
+        async def cleanup():
+            # cleanup
+            self.client.retry = False
+            self.client_task.cancel()
+            await self.client_task
+
+            await self.csc.close()
+            await self.remote.close()
+            for remote in self.client.producer.remote_list:
+                await remote.close()
+
+        await self.harness(act_assert, arrange, cleanup)

--- a/producer/telemetries/test_client.py
+++ b/producer/telemetries/test_client.py
@@ -116,7 +116,7 @@ class TestTelemetriesClient(test_utils.WSClientTestCase):
 
             # with patch("builtins.open", mock_open(read_data=json.dumps(config))) :
             remote = salobj.Remote(domain=salobj.Domain(), name="Test", index=self.index)
-            self.client = TelemetriesClient(csc_list=csc_list, sleepDuration=0.5, remote=remote)
+            self.client = TelemetriesClient(csc_list=[], sleepDuration=0.5, remote=remote)
             self.client_task = asyncio.create_task(self.client.start_ws_client())
 
         async def act_assert(websocket, path):

--- a/producer/telemetries/test_producer.py
+++ b/producer/telemetries/test_producer.py
@@ -64,3 +64,43 @@ class TestTelemetryMessages(asynctest.TestCase):
 
         self.assertEqual(stream, expected_stream)
 
+
+    async def test_produced_message_with_telemetry_scalar_with_existing_remote(self):
+        # Arrange
+        remote = salobj.Remote(domain=self.csc.domain, name="Test", index=self.csc.salinfo.index)
+        self.telemetry_producer = TelemetriesProducer(
+            domain=None, csc_list=[], remote=remote
+        )
+
+        cmd_data_sent = self.csc.make_random_cmd_scalars()
+
+        # Act
+        await self.remote.cmd_setScalars.start(cmd_data_sent, timeout=STD_TIMEOUT)
+
+        tel_scalars = await self.remote.tel_scalars.next(
+            flush=False, timeout=STD_TIMEOUT
+        )
+        tel_parameters = tel_scalars._member_attributes
+        expected_stream = {
+            p: {
+                "value": getattr(tel_scalars, p),
+                "dataType": utils.getDataType(getattr(tel_scalars, p)),
+                "units": f"{self.remote.tel_scalars.metadata.field_info[p].units}",
+            }
+            for p in tel_parameters
+            if p != "private_rcvStamp"
+        }
+
+        # extracting the message should be made synchronously
+        message = self.telemetry_producer.get_telemetry_message()
+        stream = utils.get_event_stream(
+            message, "telemetry", "Test", self.csc.salinfo.index, "scalars"
+        )
+
+        # Assert
+
+        # private_rcvStamp is generated on read and seems unpredictable now
+        del stream["private_rcvStamp"]
+
+        self.assertEqual(stream, expected_stream)
+


### PR DESCRIPTION
Refactor to decrease the number of Remotes, by adding an optional Remote param to the events, telemetries and heartbeats clients. Also removes the `initial_state` remotes from the events producer, by saving the initial state data into a local dictionary