### PR TITLE
Add dynamic way to set lsstts/develop-env image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM lsstts/develop-env:c0010
+ARG LSSTTS_DEV_VERSION=c0010
+FROM lsstts/develop-env:${LSSTTS_DEV_VERSION}
 
 WORKDIR /usr/src/love
 COPY producer/requirements.txt .

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,4 +1,5 @@
-FROM lsstts/develop-env:c0010
+ARG LSSTTS_DEV_VERSION=c0010
+FROM lsstts/develop-env:${LSSTTS_DEV_VERSION}
 
 WORKDIR /usr/src/love/producer
 COPY producer/requirements.txt .

--- a/Dockerfile-lovecsc-dev
+++ b/Dockerfile-lovecsc-dev
@@ -1,5 +1,6 @@
 # loads files from volumes
-FROM lsstts/develop-env:c0010
+ARG LSSTTS_DEV_VERSION=c0010
+FROM lsstts/develop-env:${LSSTTS_DEV_VERSION}
 WORKDIR /usr/src/love/producer/love_csc
 COPY producer/love_csc/requirements.txt ./requirements.txt
 RUN source /opt/lsst/software/stack/loadLSST.bash && pip install -r ./requirements.txt

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,7 @@ pipeline {
     dockerImageName = "lsstts/love-producer:"
     dockerImage = ""
     dockerLoveCSCImageName = "lsstts/love-csc:"
+    LSSTTS_DEV_VERSION = "c0016.001"
   }
 
   stages {
@@ -32,7 +33,7 @@ pipeline {
           }
           dockerImageName = dockerImageName + image_tag
           echo "dockerImageName: ${dockerImageName}"
-          dockerImage = docker.build dockerImageName
+          dockerImage = docker.build(dockerImageName, "--build-arg LSSTTS_DEV_VERSION=${LSSTTS_DEV_VERSION} .")
         }
       }
     }


### PR DESCRIPTION
This PR makes a refactor to the deploy infrastructure in order to dynamically set the lsstts/develop-env image version. This change is related to the following PR of the LOVE-integration-tools repo: lsst-ts/LOVE-integration-tools#76