### PR TITLE
Fix ScriptQueue not properly setting up callbacks

### DIFF
--- a/producer/csc/client.py
+++ b/producer/csc/client.py
@@ -52,13 +52,12 @@ class CSCWSClient(BaseWSClient):
             self.heartbeats_producers.append(hb_producer)
 
             if name == "ScriptQueue":
-                self.scriptqueue_clients.append(loop.create_task(self.start_scriptqueues))
+                self.scriptqueue_clients.append(loop.create_task(self.start_scriptqueues()))
 
         self.connection_error = False
 
-    async def start_scriptqueues(self, remote):
-        await asyncio.gather(*self.events_clients)
-        await scriptqueue(remote=remote)
+    async def start_scriptqueues(self):
+        await asyncio.gather(*self.events_clients, scriptqueue())
 
 
     async def on_start_client(self):


### PR DESCRIPTION
Fixes ScriptQueue not properly setting up callbacks in live-csc configuration, due to the EventsClient setting them up first 