### PR TITLE
Add lsstts/develop-env to docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG LSSTTS_DEV_VERSION=c0010
+ARG LSSTTS_DEV_VERSION=develop
 FROM lsstts/develop-env:${LSSTTS_DEV_VERSION}
 
 WORKDIR /usr/src/love

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,4 +1,4 @@
-ARG LSSTTS_DEV_VERSION=c0010
+ARG LSSTTS_DEV_VERSION=develop
 FROM lsstts/develop-env:${LSSTTS_DEV_VERSION}
 
 WORKDIR /usr/src/love/producer

--- a/Dockerfile-lovecsc
+++ b/Dockerfile-lovecsc
@@ -1,5 +1,6 @@
-# loads files from volumes
-FROM lsstts/develop-env:c0010
+ARG LSSTTS_DEV_VERSION=develop
+FROM lsstts/develop-env:${LSSTTS_DEV_VERSION}
+
 WORKDIR /usr/src/love/producer/love_csc
 COPY producer/love_csc/requirements.txt ./requirements.txt
 RUN source /opt/lsst/software/stack/loadLSST.bash && pip install -r ./requirements.txt

--- a/Dockerfile-lovecsc-dev
+++ b/Dockerfile-lovecsc-dev
@@ -1,5 +1,5 @@
 # loads files from volumes
-ARG LSSTTS_DEV_VERSION=c0010
+ARG LSSTTS_DEV_VERSION=develop
 FROM lsstts/develop-env:${LSSTTS_DEV_VERSION}
 WORKDIR /usr/src/love/producer/love_csc
 COPY producer/love_csc/requirements.txt ./requirements.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile-dev
+      args:
+        LSSTTS_DEV_VERSION: c0017.000
     image: love-producer-image-mount
     volumes:
       - .:/usr/src/love


### PR DESCRIPTION
This PR makes a small change on the Dockerfiles and docker-compose files to include the development version of the lsst develop environment