### PR TITLE
Stop installing ts-idl in the `Dockerfile-deploy` as that is already …

### DIFF
--- a/Dockerfile-deploy
+++ b/Dockerfile-deploy
@@ -8,7 +8,6 @@ COPY producer/requirements.txt .
 ARG idl
 RUN source /home/saluser/.setup_sal_env.sh && \
     pip install kafkit[aiohttp] aiokafka && \
-    conda install -c lsstts ts-idl=${idl} && \
     pip install -r requirements.txt
 
 COPY producer ./producer

--- a/producer/start-daemon-deploy.sh
+++ b/producer/start-daemon-deploy.sh
@@ -6,5 +6,9 @@ if [[ $LSST_DDS_IP != *"."* ]]; then
   echo "Unset LSST_DDS_IP"
   unset LSST_DDS_IP
 fi
-/home/saluser/repos/ts_sal/bin/make_idl_files.py LOVE
-python -u /usr/src/love/producer/main.py
+
+python -u /usr/src/love/producer/main.py &
+
+pid="$!"
+
+wait ${pid}


### PR DESCRIPTION
…part of the base container.

Stop building LOVE idl files in the start up script.
Use signal trap to properly close container and not kill the ospl daemon.