### PR TITLE
Script logMessages is not compatible with the new Producer version

### DIFF
--- a/producer/base_ws_client.py
+++ b/producer/base_ws_client.py
@@ -85,6 +85,8 @@ class BaseWSClient:
                         )
 
                     await self.on_connected()
+                    # DEPRECATED: now heartbeats are handled using SALobj events callbacks
+                    self.heartbeat_task = asyncio.create_task(self.start_heartbeat())
                     await self.handle_message_reception()
             except Exception as e:
                 self.websocket = None

--- a/producer/base_ws_client.py
+++ b/producer/base_ws_client.py
@@ -59,17 +59,21 @@ class BaseWSClient:
                     self.websocket = await session.ws_connect(self.url)
                     print(f"### {self.name} | loaded ws")
 
+                    csc = "all"
+                    if self.remote_name == "ScriptQueue":
+                        csc = "Script"
+                    elif self.remote_name:
+                        csc = self.remote_name
+
                     initial_state_subscribe_msg = {
                         "option": "subscribe",
                         "category": "initial_state",
-                        "csc": self.remote_name or "all",
+                        "csc": csc,
                         "salindex": "all",
                         "stream": "all",
                     }
                     await self.send_message(initial_state_subscribe_msg)
-                    print(
-                        f"### {self.name} | subscribed to initial state of {self.remote_name or 'all'} CSC"
-                    )
+                    print(f"### {self.name} | subscribed to initial state of {csc} CSC")
 
                     await self.on_connected()
                     await self.handle_message_reception()

--- a/producer/base_ws_client.py
+++ b/producer/base_ws_client.py
@@ -25,6 +25,7 @@ class BaseWSClient:
         self.retry = True
         self.websocket = None
         self.heartbeat_task = None
+        self.remote_name = None
 
     async def handle_message_reception(self):
         """Handles the reception of messages from the LOVE-manager,
@@ -37,6 +38,7 @@ class BaseWSClient:
                         continue
                     await self.on_websocket_receive(msg)
 
+    # DEPRECATED: now heartbeats are handled using SALobj events callbacks
     async def start_heartbeat(self):
         """Sends its heartbeat periodically."""
         while True:
@@ -56,18 +58,20 @@ class BaseWSClient:
                 async with aiohttp.ClientSession() as session:
                     self.websocket = await session.ws_connect(self.url)
                     print(f"### {self.name} | loaded ws")
+
                     initial_state_subscribe_msg = {
                         "option": "subscribe",
                         "category": "initial_state",
-                        "csc": "all",
+                        "csc": self.remote_name or "all",
                         "salindex": "all",
                         "stream": "all",
                     }
                     await self.send_message(initial_state_subscribe_msg)
+                    print(
+                        f"### {self.name} | subscribed to initial state of {self.remote_name or 'all'} CSC"
+                    )
 
-                    print(f"### {self.name} | subscribed to initial state")
                     await self.on_connected()
-                    # self.heartbeat_task = asyncio.create_task(self.start_heartbeat())
                     await self.handle_message_reception()
             except Exception as e:
                 self.websocket = None

--- a/producer/base_ws_client.py
+++ b/producer/base_ws_client.py
@@ -86,7 +86,7 @@ class BaseWSClient:
 
                     await self.on_connected()
                     # DEPRECATED: now heartbeats are handled using SALobj events callbacks
-                    self.heartbeat_task = asyncio.create_task(self.start_heartbeat())
+                    # self.heartbeat_task = asyncio.create_task(self.start_heartbeat())
                     await self.handle_message_reception()
             except Exception as e:
                 self.websocket = None

--- a/producer/base_ws_client.py
+++ b/producer/base_ws_client.py
@@ -59,21 +59,30 @@ class BaseWSClient:
                     self.websocket = await session.ws_connect(self.url)
                     print(f"### {self.name} | loaded ws")
 
-                    csc = "all"
-                    if self.remote_name == "ScriptQueue":
-                        csc = "Script"
-                    elif self.remote_name:
-                        csc = self.remote_name
-
                     initial_state_subscribe_msg = {
                         "option": "subscribe",
                         "category": "initial_state",
-                        "csc": csc,
+                        "csc": self.remote_name or "all",
                         "salindex": "all",
                         "stream": "all",
                     }
                     await self.send_message(initial_state_subscribe_msg)
-                    print(f"### {self.name} | subscribed to initial state of {csc} CSC")
+                    print(
+                        f"### {self.name} | subscribed to initial state of {self.remote_name or 'all'} CSC"
+                    )
+
+                    if self.remote_name == "ScriptQueue":
+                        initial_state_subscribe_msg = {
+                            "option": "subscribe",
+                            "category": "initial_state",
+                            "csc": "Script",
+                            "salindex": "all",
+                            "stream": "all",
+                        }
+                        await self.send_message(initial_state_subscribe_msg)
+                        print(
+                            f"### {self.name} | subscribed to initial state of Script CSC"
+                        )
 
                     await self.on_connected()
                     await self.handle_message_reception()

--- a/producer/csc/client.py
+++ b/producer/csc/client.py
@@ -68,7 +68,7 @@ class CSCWSClient(BaseWSClient):
         """ Initializes producer's callbacks """
         self.connection_error = False
 
-    async def send_heartbeat(self, message):
+    def send_heartbeat(self, message):
         """Callback used by the heartbeats producer to send messages with the websocket client
 
         Parameters
@@ -76,7 +76,6 @@ class CSCWSClient(BaseWSClient):
         message: dictionmary
             Message to send
         """
-        print(f"Sending CSC {self.csc_list} heartbeat...")
         asyncio.create_task(self.send_message(message))
 
     async def on_websocket_error(self, e):

--- a/producer/csc/client.py
+++ b/producer/csc/client.py
@@ -68,7 +68,7 @@ class CSCWSClient(BaseWSClient):
         """ Initializes producer's callbacks """
         self.connection_error = False
 
-    def send_heartbeat(self, message):
+    async def send_heartbeat(self, message):
         """Callback used by the heartbeats producer to send messages with the websocket client
 
         Parameters

--- a/producer/events/client.py
+++ b/producer/events/client.py
@@ -17,10 +17,14 @@ class EventsWSClient(BaseWSClient):
 
     def __init__(self, csc_list=None, heartbeat_callback=None, remote=None):
         super().__init__(name="Events")
+
         if csc_list is not None:
             print("CSC list replaced by", csc_list)
             self.csc_list = csc_list
+
         self.connection_error = False
+        self.remote_name = remote.salinfo.name if remote else None
+
         self.producer = EventsProducer(
             self.domain,
             self.csc_list,

--- a/producer/events/producer.py
+++ b/producer/events/producer.py
@@ -168,7 +168,7 @@ class EventsProducer:
         salindex = int(request_data["salindex"])
         event_name = request_data["data"]["event_name"]
         if (csc, salindex) not in self.remote_dict:
-            if self.auto_remote_creation:
+            if self.auto_remote_creation or csc == "Script":
                 try:
                     self.remote_dict[(csc, salindex)] = salobj.Remote(
                         self.domain, csc, salindex

--- a/producer/scriptqueue/client.py
+++ b/producer/scriptqueue/client.py
@@ -11,9 +11,12 @@ class ScriptQueueWSClient(BaseWSClient):
 
     def __init__(self, salindex, remote=None):
         super().__init__(name=f"ScriptQueue-{salindex}")
+
         self.name = f"ScriptQueue-{salindex}"
         self.connection_error = False
         self.salindex = salindex
+        self.remote_name = remote.salinfo.name if remote else None
+
         self.producer = ScriptQueueProducer(
             self.domain, self.send_message_callback, self.salindex, remote
         )

--- a/producer/telemetries/client.py
+++ b/producer/telemetries/client.py
@@ -15,9 +15,10 @@ class TelemetriesClient(BaseWSClient):
             self.csc_list = csc_list
             print("CSCs to listen replaced by", csc_list)
 
-        self.producer = TelemetriesProducer(self.domain, self.csc_list, remote)
-
         self.sleep_duration = sleep_duration
+        self.remote_name = remote.salinfo.name if remote else None
+
+        self.producer = TelemetriesProducer(self.domain, self.csc_list, remote)
 
     async def on_start_client(self):
         """ Initializes the websocket client and producer callbacks """


### PR DESCRIPTION
The new version of the LOVE-producer doesn't work properly with the Script CSC, as it uses dynamic salindexes. As the CSCSummary component works with specific CSC:salindex, this event logMessages is not received because there doesn't exists a LOVE-producer container for that specific CSC:salindex. This PR makes the necessary refactor.