### PR TITLE
Update test due to a recent change on the CSC client

### DIFF
--- a/producer/csc/test_client.py
+++ b/producer/csc/test_client.py
@@ -43,7 +43,7 @@ class TestCSCClient(test_utils.WSClientTestCase):
                 {
                     "option": "subscribe",
                     "category": "initial_state",
-                    "csc": "all",
+                    "csc": "Test",
                     "salindex": "all",
                     "stream": "all",
                 },


### PR DESCRIPTION
The previous PR made some changes to the CSC Client. This changes weren't reflected on the corresponding test so this PR makes those changes