### PR TITLE
Rollback package installation to runtime

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -2,12 +2,10 @@ ARG dev_cycle=develop
 FROM lsstts/develop-env:${dev_cycle}
 
 WORKDIR /usr/src/love/
-COPY . .
-
+COPY requirements.txt .
 RUN source /opt/lsst/software/stack/loadLSST.bash && \
 	pip install kafkit[aiohttp] aiokafka && \
-	pip install -r requirements.txt && \
-	pip install -e .
+	pip install -r requirements.txt
 
 WORKDIR /home/saluser
 CMD ["/usr/src/love/producer/start-daemon.sh"]

--- a/producer/start-daemon.sh
+++ b/producer/start-daemon.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 . /home/saluser/.setup_dev.sh
+pip install -e /usr/src/love/
 run_love_producer


### PR DESCRIPTION
This PR is a hot fix that rollback a previous change that moved the package installation to build time. Due to some problems with the development environment we had to keep the package installation at runtime.