### PR TITLE
Remove editable mode for pip install

### DIFF
--- a/.env
+++ b/.env
@@ -6,4 +6,4 @@ cycle=c0014
 #
 # Development cycle to build
 #
-dev_cycle=c0020.001
+dev_cycle=c0020.006

--- a/producer/start-daemon.sh
+++ b/producer/start-daemon.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 . /home/saluser/.setup_dev.sh
-pip install -e /usr/src/love/
+pip install /usr/src/love/
 run_love_producer

--- a/tests/scriptqueue/test_available.py
+++ b/tests/scriptqueue/test_available.py
@@ -19,7 +19,7 @@ class TestScriptqueueAvailableScripts(asynctest.TestCase):
     maxDiff = None
 
     async def tearDown(self):
-        nkilled = len(self.queue.model.terminate_all())
+        nkilled = len(await self.queue.model.terminate_all())
         if nkilled > 0:
             warnings.warn(f"Killed {nkilled} subprocesses")
         await asyncio.wait_for(self.queue.close(), TIMEOUT)


### PR DESCRIPTION
This is a small PR to remove the editable mode of the package installation on the `start-daemon.sh` file. This was generating some problems on development environments.