### PR TITLE
Adjust permissions on Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,11 @@ FROM lsstts/develop-env:${dev_cycle}
 WORKDIR /usr/src/love
 COPY . .
 
-RUN source /opt/lsst/software/stack/loadLSST.bash && \
+USER root
+RUN chown -R saluser:saluser /usr/src/love
+USER saluser
+
+RUN source /home/saluser/.setup_dev.sh && \
 	pip install -r requirements.txt && \
 	pip install /usr/src/love
 


### PR DESCRIPTION
This PR fix a permission problem when trying to build the `docker/Dockerfile` image. As the `pip install` command creates a `python/love/producer/version.py` file it was necessary to change the ownership of the folder so the command could work. Also the `source /opt/lsst/software/stack/loadLSST.bash` was change to `source /home/saluser/.setup_dev.sh` as the previous command will be deprecated.