### PR TITLE
Refactor Watcher alarms handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,11 +6,11 @@ repos:
         exclude: conda/meta.yaml
 
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.3.0
     hooks:
       - id: black
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 4.0.1
     hooks:
       - id: flake8

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v6.5.0
+-------
+
+* Refactor Watcher alarms handling `<https://github.com/lsst-ts/LOVE-producer/pull/138>`_
+
 v6.4.4
 -------
 

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -10,4 +10,5 @@ RUN source /opt/lsst/software/stack/loadLSST.bash && \
 	pip install -r requirements.txt
 
 WORKDIR /home/saluser
+USER root
 CMD ["/usr/src/love/docker/start-daemon-dev.sh"]

--- a/python/love/producer/love_producer_factory.py
+++ b/python/love/producer/love_producer_factory.py
@@ -26,6 +26,7 @@ from lsst.ts import salobj
 from . import LoveProducerBase
 from . import LoveProducerCSC
 from . import LoveProducerScriptQueue
+from . import LoveProducerWatcher
 from . import get_available_components
 
 
@@ -34,10 +35,12 @@ class LoveProducerFactory:
         base=LoveProducerBase,
         csc=LoveProducerCSC,
         scriptqueue=LoveProducerScriptQueue,
+        watcher=LoveProducerWatcher,
     )
 
     named_love_producer_type = dict(
         ScriptQueue="scriptqueue",
+        Watcher="watcher",
     )
 
     @classmethod

--- a/python/love/producer/love_producer_watcher.py
+++ b/python/love/producer/love_producer_watcher.py
@@ -54,6 +54,18 @@ class LoveProducerWatcher(LoveProducerCSC):
 
         self.register_asynchronous_data_category("stream", "_stream")
         self.store_samples(_stream=self.alarms_state_message_data)
+    
+    def add_new_alarm(self, alarm: dict) -> None:
+        """Add a new alarm to the alarms state."""
+        try:
+            existent_alarm_index = [a.name for a in self.alarms_state].index(alarm["name"])
+            self.alarms_state[existent_alarm_index] = alarm
+        except ValueError:
+            self.alarms_state.append(alarm)
+        
+        # Truncate the alarms state to the last 30 alarms.
+        if len(self.alarms_state) > 30:
+            self.alarms_state = self.alarms_state[-30:]
 
     async def handle_event_watcher_alarm(self, event: Any) -> None:
         """Handle the Watcher_logevent_alarm event.
@@ -71,7 +83,7 @@ class LoveProducerWatcher(LoveProducerCSC):
         """
         _, data_as_dict = self._convert_data_to_dict(event)
         new_alarm = data_as_dict["data"]["alarm"][0].copy()
-        self.alarms_state.append(new_alarm)
+        self.add_new_alarm(new_alarm)
         self.store_samples(_stream=self.alarms_state_message_data)
         await self.send_watcher_alarms()
 

--- a/python/love/producer/love_producer_watcher.py
+++ b/python/love/producer/love_producer_watcher.py
@@ -98,5 +98,5 @@ class LoveProducerWatcher(LoveProducerCSC):
         return dict(
             csc="Watcher",
             salindex=self.remote.salinfo.index,
-            data=dict(stream=[data]),
+            data=dict(stream=data),
         )

--- a/python/love/producer/love_producer_watcher.py
+++ b/python/love/producer/love_producer_watcher.py
@@ -69,10 +69,8 @@ class LoveProducerWatcher(LoveProducerCSC):
         Watcher_logevent_alarm event. It stores alarms in the
         `alarms_state` attribute and sends them to the LOVE manager.
         """
-        new_alarm = dict()
-        new_alarm["name"] = event.name
-        new_alarm["severity"] = event.severity
-        new_alarm["max_severity"] = event.maxSeverity
+        _, data_as_dict = self._convert_data_to_dict(event)
+        new_alarm = data_as_dict["data"]["alarm"][0].copy()
         self.alarms_state.append(new_alarm)
         self.store_samples(_stream=self.alarms_state_message_data)
         await self.send_watcher_alarms()

--- a/python/love/producer/love_producer_watcher.py
+++ b/python/love/producer/love_producer_watcher.py
@@ -31,7 +31,9 @@ from . import LoveProducerCSC
 class LoveProducerWatcher(LoveProducerCSC):
     """Specialized LOVE producer to deal with the Watcher CSC."""
 
-    def __init__(self, domain: Domain, log: Optional[logging.Logger] = None, **kwargs) -> None:
+    def __init__(
+        self, domain: Domain, log: Optional[logging.Logger] = None, **kwargs
+    ) -> None:
         kwargs_reformatted = kwargs.copy()
         if "csc" in kwargs_reformatted:
             kwargs_reformatted.pop("csc")
@@ -45,24 +47,24 @@ class LoveProducerWatcher(LoveProducerCSC):
         )
 
         self.alarms_state = []
-        
+
         self._non_topic_data_stream = {"stream"}
 
-        self.register_additional_action(
-            "evt_alarm", self.handle_event_watcher_alarm
-        )
+        self.register_additional_action("evt_alarm", self.handle_event_watcher_alarm)
 
         self.register_asynchronous_data_category("stream", "_stream")
         self.store_samples(_stream=self.alarms_state_message_data)
-    
+
     def add_new_alarm(self, alarm: dict) -> None:
         """Add a new alarm to the alarms state."""
         try:
-            existent_alarm_index = [a.name for a in self.alarms_state].index(alarm["name"])
+            existent_alarm_index = [a.name for a in self.alarms_state].index(
+                alarm["name"]
+            )
             self.alarms_state[existent_alarm_index] = alarm
         except ValueError:
             self.alarms_state.append(alarm)
-        
+
         # Truncate the alarms state to the last 30 alarms.
         if len(self.alarms_state) > 30:
             self.alarms_state = self.alarms_state[-30:]
@@ -74,7 +76,7 @@ class LoveProducerWatcher(LoveProducerCSC):
         ----------
         event : `Watcher_logevent_script`
             Watcher_logevent_script event data.
-        
+
         Notes
         -----
         This method is registered as an additional action for the
@@ -90,14 +92,14 @@ class LoveProducerWatcher(LoveProducerCSC):
     async def send_watcher_alarms(self) -> None:
         """Send the watcher alarms to the LOVE manager."""
         await self.send_message(self.get_alarms_state_as_json())
-    
+
     def get_alarms_state_as_json(self) -> str:
         """Get the alarms state as a JSON string."""
         return self._love_manager_message.get_message_category_as_json(
             category="event",
             data=self.alarms_state_message_data,
         )
-    
+
     @property
     def alarms_state_message_data(self) -> dict:
         """Get the alarms state as a dictionary."""
@@ -109,4 +111,3 @@ class LoveProducerWatcher(LoveProducerCSC):
             salindex=self.remote.salinfo.index,
             data=dict(stream=data),
         )
-

--- a/python/love/producer/love_producer_watcher.py
+++ b/python/love/producer/love_producer_watcher.py
@@ -21,8 +21,82 @@
 
 __all__ = ["LoveProducerWatcher"]
 
+import logging
+from typing import Any, Optional
+from lsst.ts.salobj import Domain
+
 from . import LoveProducerCSC
 
 
 class LoveProducerWatcher(LoveProducerCSC):
     """Specialized LOVE producer to deal with the Watcher CSC."""
+
+    def __init__(self, domain: Domain, log: Optional[logging.Logger] = None, **kwargs) -> None:
+        kwargs_reformatted = kwargs.copy()
+        if "csc" in kwargs_reformatted:
+            kwargs_reformatted.pop("csc")
+
+        super().__init__(
+            domain=domain,
+            csc="Watcher",
+            log=log,
+            remote_readonly=False,
+            **kwargs_reformatted,
+        )
+
+        self.alarms_state = []
+        
+        self._non_topic_data_stream = {"stream"}
+
+        self.register_additional_action(
+            "evt_alarm", self.handle_event_watcher_alarm
+        )
+
+        self.register_asynchronous_data_category("stream", "_stream")
+        self.store_samples(_stream=self.alarms_state_message_data)
+
+    async def handle_event_watcher_alarm(self, event: Any) -> None:
+        """Handle the Watcher_logevent_alarm event.
+
+        Parameters
+        ----------
+        event : `Watcher_logevent_script`
+            Watcher_logevent_script event data.
+        
+        Notes
+        -----
+        This method is registered as an additional action for the
+        Watcher_logevent_alarm event. It stores alarms in the
+        `alarms_state` attribute and sends them to the LOVE manager.
+        """
+        new_alarm = dict()
+        new_alarm["name"] = event.name
+        new_alarm["severity"] = event.severity
+        new_alarm["max_severity"] = event.maxSeverity
+        self.alarms_state.append(new_alarm)
+        self.store_samples(_stream=self.alarms_state_message_data)
+        await self.send_watcher_alarms()
+
+    async def send_watcher_alarms(self) -> None:
+        """Send the watcher alarms to the LOVE manager."""
+        await self.send_message(self.get_alarms_state_as_json())
+    
+    def get_alarms_state_as_json(self) -> str:
+        """Get the alarms state as a JSON string."""
+        return self._love_manager_message.get_message_category_as_json(
+            category="event",
+            data=self.alarms_state_message_data,
+        )
+    
+    @property
+    def alarms_state_message_data(self) -> dict:
+        """Get the alarms state as a dictionary."""
+        data = dict(
+            alarms=self.alarms_state,
+        )
+        return dict(
+            csc="Watcher",
+            salindex=self.remote.salinfo.index,
+            data=dict(stream=data),
+        )
+


### PR DESCRIPTION
This PR extends the Watcher producer in order to store alarms in memory. Now everytime a `Watcher_logevent_alarm` event is received, that alarms is stored, but not sent. The full payload (with all stored alarms) will be sent only when the respective `initial_state` is requested, thus only when starting the producer and when a new consumer is connected (e.g. a user opens a interface).