### PR TITLE
Remove authlist references

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,9 +2,12 @@
 Version History
 ===============
 
+
+
 v6.6.0
 ------
 
+* Remove authlist references `<https://github.com/lsst-ts/LOVE-producer/pull/148>`_
 * Refactor ScriptQueueState payload into several `<https://github.com/lsst-ts/LOVE-producer/pull/147>`_
 
 v6.5.4

--- a/tests/test_love_producer_script_queue.py
+++ b/tests/test_love_producer_script_queue.py
@@ -175,7 +175,6 @@ class TestLoveProducerScriptQueue(unittest.IsolatedAsyncioTestCase):
                 ("softwareVersions", 1),
                 ("simulationMode", 1),
                 ("logLevel", 1),
-                ("authList", 1),
             ]
 
             for event_name, minimum_samples in expected_events_samples:

--- a/tests/test_love_producer_script_queue.py
+++ b/tests/test_love_producer_script_queue.py
@@ -331,6 +331,7 @@ class TestLoveProducerScriptQueue(unittest.IsolatedAsyncioTestCase):
 
     async def test_available_scripts_state_message_data(self):
         state_minimum_samples = 1
+        self.standard_timeout = 10
 
         async with self.enable_script_queue():
             await self.assert_minimum_samples_of(


### PR DESCRIPTION
This PR removes all references to the Authlist feature as the Authorize CSC has been removed from the Control System.