### PR TITLE
Log exception to identify issues when the producer process ends suddenly.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v6.7.0
 ------
 
+* Log exception to identify issues when the producer process ends suddenly. `<https://github.com/lsst-ts/LOVE-producer/pull/151>`_
 * Limit size of stored finished scripts list. `<https://github.com/lsst-ts/LOVE-producer/pull/150>`_
 
 v6.6.1

--- a/python/love/producer/love_producer_set.py
+++ b/python/love/producer/love_producer_set.py
@@ -83,8 +83,8 @@ class LoveProducerSet:
         ):
             try:
                 await task
-            except Exception:
-                self.log.exception("Error in execution task.")
+            except Exception as e:
+                self.log.exception(f"Error in execution task: {e}")
             finally:
                 break
 


### PR DESCRIPTION
This PR extends the exception logging in the `love_producer_set.py` to allow debuging more details on the errors that make the producer process to end.