### PR TITLE
Make subscriptions to initial state periodically.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v6.8.0
+------
+
+* Make subscriptions to initial state periodically. `<https://github.com/lsst-ts/LOVE-producer/pull/152>`_
+
 v6.7.0
 ------
 


### PR DESCRIPTION
This PR adds a loop to make periodically registration of producers to initial state channels  (so then when frontend clients connect producers are able to receive messages requesting for last telemetry values). This is related also with a LOVE-manager PR: https://github.com/lsst-ts/LOVE-manager/pull/296 which will reduce the redis_layer channels expiration, hence the need of making periodical subscriptions in case of a channel expiration.