### PR TITLE
Make scripts schemas load on startup optional for the love_producer_script_queue.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v6.8.0
 ------
 
+* Make scripts schemas load on startup optional for the love_producer_script_queue. `<https://github.com/lsst-ts/LOVE-producer/pull/153>`_
 * Make subscriptions to initial state periodically. `<https://github.com/lsst-ts/LOVE-producer/pull/152>`_
 
 v6.7.0

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ All these variables are initialized with default variables defined in the :code:
 - ``LSST_DDS_PARTITION_PREFIX``: Prefix of the DDS partition to use.
 - ``PROCESS_CONNECTION_PASS``: Password use to authenticate connections with the LOVE-manager.
 - ``LOVE_CSC_PRODUCER``: Name and salindex of the CSC to connect in the format `<CSC>:<salindex>`. E.g. `ATDome:0`.
+- ``FINISHED_SCRIPTS_LIST_SIZE``: Size of the list of finished scripts to keep in memory for the ScriptQueue producer.
+- ``UPDATE_SCRIPTS_SCHEMA_ON_START``: If `True`, the producer will update the scripts schema on start.
 
 ## Use as part of the LOVE system
 

--- a/python/love/producer/love_producer_script_queue.py
+++ b/python/love/producer/love_producer_script_queue.py
@@ -344,8 +344,9 @@ class LoveProducerScriptQueue(LoveProducerCSC):
         )
         await self.send_available_scripts()
 
-        self.log.debug("Scheduling update of script schemas.")
-        self.scripts_schema_task = asyncio.create_task(self.update_scripts_schema())
+        if self.update_scripts_schema_on_start:
+            self.log.debug("Scheduling update of script schemas.")
+            self.scripts_schema_task = asyncio.create_task(self.update_scripts_schema())
 
     async def handle_event_scriptqueue_config_schema(self, event: Any) -> None:
         """Additional action for configSchema event.
@@ -869,3 +870,10 @@ class LoveProducerScriptQueue(LoveProducerCSC):
     @property
     def finished_scripts_list_size(self) -> int:
         return int(os.environ.get("FINISHED_SCRIPTS_LIST_SIZE", 10))
+
+    @property
+    def update_scripts_schema_on_start(self) -> bool:
+        return os.environ.get("UPDATE_SCRIPTS_SCHEMA_ON_START", "False").lower() in (
+            "true",
+            "1",
+        )


### PR DESCRIPTION
This PR refactors the `love_producer_script_queue.py` file to make the scripts schemas load on startup optional. A new environment variable configuration was added to support turning on or off this feature. This is related to a LOVE-frontend PR: https://github.com/lsst-ts/LOVE-frontend/pull/680.