### PR TITLE
Update love producer to support splitting up telemetries.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v7.1.0
+------
+
+* Update love producer to support splitting up telemetries. `<https://github.com/lsst-ts/LOVE-producer/pull/155>`_
+
 v7.0.0
 ------
 

--- a/python/love/producer/love_producer_set.py
+++ b/python/love/producer/love_producer_set.py
@@ -37,7 +37,7 @@ logging.basicConfig(level=logging.DEBUG)
 class LoveProducerSet:
     """Container class to configure and host a list of LOVE producers."""
 
-    def __init__(self, components, log_level=logging.INFO) -> None:
+    def __init__(self, components, log_level=logging.INFO, **kwargs) -> None:
         self.log = logging.getLogger()
 
         if not self.log.hasHandlers():
@@ -54,6 +54,7 @@ class LoveProducerSet:
             components=components,
             domain=self.domain,
             log=self.log,
+            **kwargs,
         )
 
         self.standard_timeout = 5.0
@@ -113,9 +114,16 @@ class LoveProducerSet:
                 "See `--help` for more information."
             )
 
+        kwargs = dict()
+        if args.periodic_data is not None:
+            kwargs["periodic_data"] = args.periodic_data
+        if args.asynchronous_data is not None:
+            kwargs["asynchronous_data"] = args.asynchronous_data
+
         love_producer_set = cls(
             components=args.components,
             log_level=args.log_level,
+            **kwargs,
         )
 
         await love_producer_set.run_producer()
@@ -132,6 +140,19 @@ class LoveProducerSet:
             "components",
             nargs="*",
             help="Names of SAL components, e.g. ATDome, ATDomeTrajectory, MTHexapod:1.",
+        )
+
+        parser.add_argument(
+            "--periodic-data",
+            nargs="*",
+            help="Optional list of topic names to treat as periodic data"
+            "(will be pooled at set frequency, e.g. telemetry).",
+        )
+
+        parser.add_argument(
+            "--asynchronous-data",
+            nargs="*",
+            help="Optional list of topic names to treat as asynchonous data (e.g. events).",
         )
 
         parser.add_argument(

--- a/tests/test_love_manager_client.py
+++ b/tests/test_love_manager_client.py
@@ -243,7 +243,7 @@ class TestLoveManagerClient(unittest.IsolatedAsyncioTestCase):
         self._run_wesocket_server = True
 
         socket = websockets.serve(
-            ws_handler=self.handle_websocket_server_received_message,
+            handler=self.handle_websocket_server_received_message,
             host="0.0.0.0",
             port=9999,
         )
@@ -254,7 +254,7 @@ class TestLoveManagerClient(unittest.IsolatedAsyncioTestCase):
         finally:
             self.log.info("Closing web server")
             self._run_wesocket_server = False
-            socket.ws_server.close()
+            socket.server.close()
 
     @contextlib.asynccontextmanager
     async def handle_connection_with_manager(self):

--- a/tests/test_love_producer_script_queue.py
+++ b/tests/test_love_producer_script_queue.py
@@ -254,7 +254,7 @@ class TestLoveProducerScriptQueue(unittest.IsolatedAsyncioTestCase):
             )
 
     async def test_script_log_message(self):
-        log_messages_minimum_samples = 4
+        log_messages_minimum_samples = 3
         self.standard_timeout = 20
 
         async with self.enable_script_queue():
@@ -342,7 +342,7 @@ class TestLoveProducerScriptQueue(unittest.IsolatedAsyncioTestCase):
     @pytest.mark.usefixtures("set_update_scripts_schema_env_var")
     async def test_available_scripts_state_message_data(self):
         state_minimum_samples = 2
-        self.standard_timeout = 10
+        self.standard_timeout = 30
 
         async with self.enable_script_queue():
             await self.assert_minimum_samples_of(


### PR DESCRIPTION
This PR introduces several enhancements and improvements to the `love_producer_csc` and `love_producer_set` modules. The changes mainly focus on adding new functionality to handle periodic and asynchronous data, improving logging, and updating the initialization process to support additional arguments.